### PR TITLE
Updated guidelines for test module hash name...

### DIFF
--- a/src/documents/IoCTestingFramework.md
+++ b/src/documents/IoCTestingFramework.md
@@ -104,7 +104,7 @@ as well as the test fixture code itself:
 ```javascript
 fluid.defaults("fluid.tests.catTester", {
     gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
-    testCases: [ /* declarative specification of tests */ {
+    modules: [ /* declarative specification of tests */ {
         name: "Cat test case",
         tests: [{
             expect: 1,
@@ -122,7 +122,7 @@ fluid.tests.globalCatTest = function (catt) {
 };
 ```
 
-The standard structure inside a `fluid.test.testCaseHolder` shows an outer layer of containment, `testCases`, corresponding to a 
+The standard structure inside a `fluid.test.testCaseHolder` shows an outer layer of containment, `modules`, corresponding to a 
 QUnit `module`, and then a entry named `tests`, holding an array of structures corresponding to a QUnit `testCase`. Here we define a single 
 test case which holds a single *fixture record* which executes a global function, `fluid.tests.globalCatTest` which makes one jqUnit assertion. 
 In cases where we apply *sequence testing*, the fixture record may instead hold an entry named sequence which holds an array of fixture records 
@@ -320,7 +320,7 @@ fluid.defaults("fluid.tests.asyncTester", {
     gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
     newTextValue:     "newTextValue",
     furtherTextValue: "furtherTextValue",
-    testCases: [ {
+    modules: [ {
         name: "Async test case",
         tests: [{
             name: "Rendering sequence",


### PR DESCRIPTION
In working on my first tests, I discovered that the framework will throw errors unless your test cases are stored in a `modules` hash.  The documentation previously indicated that you should use `testCases`.  I am submitting a pull request to fix this.
